### PR TITLE
make file i/o UTF-8 compatible.

### DIFF
--- a/lib/R/YapRI/Base.pm
+++ b/lib/R/YapRI/Base.pm
@@ -907,7 +907,7 @@ sub add_command {
 	my $cmdfile = $block->get_command_file();
 	if (defined $cmdfile && length($cmdfile) > 0 && -f $cmdfile) {
 	    
-	    open my $cmdfh, '>>', $cmdfile;  ## open and append
+	    open(my $cmdfh, '>> :encoding(UTF-8)', $cmdfile) || die "Can't open cmdfile $cmdfile";  ## open and append
 	    print $cmdfh "$command\n";       ## write it with breakline
 	    close($cmdfh);                   ## close it
 	}
@@ -952,7 +952,7 @@ sub get_commands {
 	my $cmdfile = $block->get_command_file();
 	if (defined $cmdfile && length($cmdfile) > 0 && -f $cmdfile) {
 	    
-	    open my $cmdfh, '+<', $cmdfile;  ## open for read
+	    open(my $cmdfh, '+< :encoding(UTF-8)', $cmdfile) || die "Can't open cmdfile $cmdfile";  ## open for read
 	    while(<$cmdfh>) {                ## read it
 		chomp($_);
 		push @commands, $_;
@@ -1274,7 +1274,7 @@ sub r_object_class {
     ## Open the result file and parse it
 
     my $resultfile = $self->get_blocks($cblock)->get_result_file();
-    open my $rfh, '<', $resultfile;
+    open(my $rfh, '< :encoding(UTF-8)', $resultfile) || die "Can't open resultfile $resultfile";
 
     my $init = 0;
     while (<$rfh>) {
@@ -1351,7 +1351,7 @@ sub r_function_args {
     $self->run_commands($block1);
     my $rfile1 = $self->get_blocks($block1)->get_result_file();
     
-    open my $rfh1, '<', $rfile1;
+    open(my $rfh1, '< :encoding(UTF-8)', $rfile1) || die "Can't open rfile1 $rfile1";
     while(<$rfh1>) {
 	if ($_ =~ m/<environment:\snamespace:(.+)>/) {
 	    $env = $1;
@@ -1374,7 +1374,7 @@ sub r_function_args {
 	$self->run_commands($block2);
 	my $rfile2 = $self->get_blocks($block2)->get_result_file();
 
-	open my $rfh2, '<', $rfile2;
+	open(my $rfh2, '< :encoding(UTF-8)', $rfile2) || die "Can't open rfile2 $rfile2";
 	
 	## Catch the defaults
 	my $fline = '';

--- a/lib/R/YapRI/Base.pm
+++ b/lib/R/YapRI/Base.pm
@@ -15,6 +15,8 @@ use File::stat;
 use R::YapRI::Interpreter::Perl qw( r_var );
 use R::YapRI::Block;
 
+use utf8;
+
 ###############
 ### PERLDOC ###
 ###############
@@ -1043,7 +1045,7 @@ sub run_commands {
 	print STDERR "RUNNING COMMAND:\n$base_cmd\n";
     }
 
-    my $run = system($base_cmd);
+    my $run = system("export LC_ALL=en_US.UTF-8; $base_cmd ");
            
     if ($run == 0) {   ## It means success	
 	$block->set_result_file($resultfile);

--- a/lib/R/YapRI/Block.pm
+++ b/lib/R/YapRI/Block.pm
@@ -13,7 +13,7 @@ use File::Path qw( make_path remove_tree);
 use File::stat;
 
 use R::YapRI::Interpreter::Perl qw( r_var );
-
+use utf8;
 
 ###############
 ### PERLDOC ###

--- a/lib/R/YapRI/Block.pm
+++ b/lib/R/YapRI/Block.pm
@@ -525,7 +525,7 @@ sub read_results {
     my $resultfile = $self->get_result_file();
     
     if (defined $resultfile) {
-	open my $rfh, '<', $resultfile;
+	open(my $rfh, '< :encoding(UTF-8)', $resultfile) || die "Can't open resultfile $resultfile";
 	while(<$rfh>) {
 	    chomp($_);
 	    push @results, $_;

--- a/lib/R/YapRI/Data/Matrix.pm
+++ b/lib/R/YapRI/Data/Matrix.pm
@@ -2088,7 +2088,7 @@ sub read_rbase {
 	matrix   => [],
 	);
 
-    open my $rfh, '<', $rfile;
+    open(my $rfh, '< :encoding(UTF-8)', $rfile) || die "Can't open rfile $rfile";
     while(<$rfh>) {
 	chomp($_);
 	if ($_ =~ m/"end_catch_matrix_$r_obj"/) {

--- a/lib/R/YapRI/Data/Matrix.pm
+++ b/lib/R/YapRI/Data/Matrix.pm
@@ -9,6 +9,7 @@ use Carp qw(croak cluck carp);
 use R::YapRI::Base;
 use R::YapRI::Interpreter::Perl qw( r_var );
 
+use utf8;
 
 ###############
 ### PERLDOC ###

--- a/lib/R/YapRI/Graph/Simple.pm
+++ b/lib/R/YapRI/Graph/Simple.pm
@@ -13,6 +13,7 @@ use R::YapRI::Interpreter::Perl qw( r_var );
 
 use R::YapRI::Data::Matrix;
 
+use utf8;
 
 ###############
 ### PERLDOC ###

--- a/lib/R/YapRI/Graph/Simple.pm
+++ b/lib/R/YapRI/Graph/Simple.pm
@@ -765,7 +765,7 @@ sub is_device_enabled {
     $rbase->add_command('print("end.dev.list")', $cblock);
     $rbase->run_commands($cblock);
     my $rfile = $rbase->get_blocks($cblock)->get_result_file();
-    open my $rfh, '<', $rfile;
+    open(my $rfh, '< :encoding(UTF-8)', $rfile) || die "Can't open rfile $rfile";
 
     my $match_region = 0;
     my $enab = 0;


### PR DESCRIPTION
All I/O needs to be done using UTF-8 encoding, to support international character sets. File read/write needs to explicitly set UTF-8 encoding.